### PR TITLE
[nginx] use security.dhparams for dhparam generation

### DIFF
--- a/modules/services/nginx/default.nix
+++ b/modules/services/nginx/default.nix
@@ -65,19 +65,13 @@ in
       }
     );
 
-    services.nginx.sslDhparam = mkIf cfg.generateDhParams (
-      mkDefault
-        "${config.services.nginx.stateDir}/dhparams-${toString cfg.dhParamBytes}.pem"
-    );
+    services.nginx.sslDhparam = mkIf cfg.generateDhParams config.security.dhparams.params.nginx.path;
 
-    systemd.services.nginx.serviceConfig.TimeoutStartSec = "10 min";
-    systemd.services.nginx.preStart = mkIf cfg.generateDhParams ''
-      #!${pkgs.stdenv.shell}
+    security.dhparams = mkIf cfg.generateDhParams {
+      enable = true;
+      params.nginx.bits = cfg.dhParamBytes;
+    };
 
-      if [ ! -f "${config.services.nginx.stateDir}/dhparams-${toString cfg.dhParamBytes}.pem" ]; then
-        ${pkgs.openssl}/bin/openssl dhparam -out "${config.services.nginx.stateDir}/dhparams-${toString cfg.dhParamBytes}.pem" ${toString cfg.dhParamBytes}
-      fi
-    '';
     networking.firewall.allowedTCPPorts = [ 80 443 ];
   };
 }

--- a/tests/make-test.nix
+++ b/tests/make-test.nix
@@ -1,0 +1,12 @@
+f: { system ? builtins.currentSystem
+   , pkgs ? import <nixpkgs> { inherit system; config = {}; }
+   , ...
+   } @ args:
+
+with import <nixpkgs/nixos/lib/testing-python.nix> { inherit system pkgs; };
+let
+  input = if pkgs.lib.isFunction f then f (args // { inherit pkgs; inherit (pkgs) lib; }) else f;
+  modules = pkgs.lib.attrValues (import ../modules);
+  nodes = pkgs.lib.mapAttrs (name: node: node // { imports = modules ++ (node.imports or []); }) input.nodes;
+in
+makeTest (input // { nodes = nodes; })

--- a/tests/nginx.nix
+++ b/tests/nginx.nix
@@ -1,0 +1,41 @@
+import ./make-test.nix (
+  { pkgs, ... }:
+    let
+      runWithOpenSSL = file: cmd: pkgs.runCommand file {
+        buildInputs = [ pkgs.openssl ];
+      } cmd;
+
+      key = runWithOpenSSL "key.pem" ''
+        openssl genrsa -out $out 2048
+      '';
+      csr = runWithOpenSSL "csr.csr" ''
+        openssl req -new -sha256 -key ${key} -out $out -subj "/CN=localhost"
+      '';
+      cert = runWithOpenSSL "cert.pem" ''
+        openssl req -x509 -sha256 -days 365 -key ${key} -in ${csr} -out $out
+      '';
+    in
+      {
+        name = "nginx";
+        nodes.default = {
+          kampka.services.nginx = {
+            enable = true;
+            dhParamBytes = 128; # probably unwise in production, but faster in tests
+          };
+          services.nginx.virtualHosts.default = {
+            default = true;
+            forceSSL = true;
+
+            sslCertificate = cert;
+            sslCertificateKey = key;
+          };
+        };
+
+        testScript =
+          ''
+            default.wait_for_unit("nginx.service")
+            default.wait_for_open_port(80)
+            default.wait_for_open_port(443)
+          '';
+      }
+)


### PR DESCRIPTION
On current 20.03, the initial start fails because the dhparams file is missing. Using `security.dhparams` instead does not have that issue.

Possible improvements/additions:
- Deprecate/remove `cfg.dhParamBytes` (the value is in bits anyway). Set `security.dhparams.defaultBitSize = mkDefault 4096;` in one of the profiles instead.
- Possibly also deprecate/remove `cfg.generateDhParams` and use `securits.dhparams.enable` instead (set it in one of the profiles).

Fixes: #6 

