### PR TITLE
[nixops-auto-upgrade] set the nixos config path name

### DIFF
--- a/modules/services/nixops-auto-upgrade/default.nix
+++ b/modules/services/nixops-auto-upgrade/default.nix
@@ -74,10 +74,14 @@ in
       '';
 
       system.activationScripts = {
-        configuration = ''
+        configuration =
+        let
+          configurationPath = builtins.path { name = "nixos-configuration"; path = cfg.configurationPath; };
+        in
+        ''
           mkdir -p /etc/nixos/current/
           rm -f /etc/nixos/current/*
-          ln -sf ${cfg.configurationPath}/* /etc/nixos/current
+          ln -sf ${configurationPath}/* /etc/nixos/current
         '';
       };
 


### PR DESCRIPTION
Without this the store path is used as a name so it gets longer with
every nixops-auto-update run and eventually breaks the 212 character
limit.

Fixes #7.